### PR TITLE
`app_faq.md` references incorrect `Cisco IOS XR` platform slug

### DIFF
--- a/docs/user/app_faq.md
+++ b/docs/user/app_faq.md
@@ -67,7 +67,7 @@ The current supported platform and the associated *default* platform slug names 
 * arista_eos
 * cisco_asa
 * cisco_ios
-* cisco_ios_xr
+* cisco_xr
 * cisco_nxos
 * juniper_junos
 


### PR DESCRIPTION
Fixes #422